### PR TITLE
Terms Style and Source Links

### DIFF
--- a/components/Term.tsx
+++ b/components/Term.tsx
@@ -16,7 +16,7 @@ export type TermProps = {
 const Term: React.FC<{ term: TermProps }> = ({ term }) => {
   return (
     <div
-      className="group text-h4 sm:text-h3 md:sm:text-h2 font-satoshi border-t-4 border-gray-500 snap-center py-3 cursor-pointer duration-100"
+      className="group text-h4 sm:text-h3 md:sm:text-h2 font-satoshi border-t border-gray-500 snap-center py-3 cursor-pointer duration-100"
       onClick={() => Router.push("/terms/[title]", `/terms/${term.id}`)}
     >
       <div className="flex justify-between  hover:duration-200 hover:bg-[#FFF] hover:rounded-lg">

--- a/pages/source/[id]/index.tsx
+++ b/pages/source/[id]/index.tsx
@@ -41,10 +41,10 @@ const Term: React.FC<TermProps> = (props) => {
       <Layout>
         <div className="mx-auto max-w-7xl ">
           <div className="text-h4 sm:text-h3 md:sm:text-h1 font-bold font-satoshi border-b-2">
-            {title}
+            <Link href={props.href}>{title} ↗</Link>{" "}
           </div>
           <div className="grid grid-cols-4">
-            <div className="col-span-1">
+            {/* <div className="col-span-1">
               <div className="">Overview</div>
               <div className="">
                 via{" "}
@@ -55,7 +55,7 @@ const Term: React.FC<TermProps> = (props) => {
                   {props?.content || "Undefinded Term"}
                 </Link>
               </div>
-            </div>
+            </div> */}
             <div className="col-span-3 text-h4 sm:text-h3 md:sm:text-h2">
               {props?.content || "Undefinded Term"}
             </div>

--- a/pages/terms/[id]/index.tsx
+++ b/pages/terms/[id]/index.tsx
@@ -49,7 +49,7 @@ const Term: React.FC<TermProps> = (props) => {
 
           <div>
             {" "}
-            <div className="grid grid-cols-4 py-9">
+            {/* <div className="grid grid-cols-4 py-9">
               <div className="col-span-4 md:col-span-1 pb-9">
                 <div className="text-h5 md:text-h3 font-bold">The Details</div>
                 {/* <div className="">
@@ -60,12 +60,12 @@ const Term: React.FC<TermProps> = (props) => {
                   >
                     source
                   </Link>
-                </div> */}
+                </div>
               </div>
               <div className="col-span-4 md:col-span-3 text-h4 sm:text-h3 md:sm:text-h2 italic">
                 Coming Soon
               </div>
-            </div>
+            </div> */}
           </div>
 
           <div>

--- a/pages/terms/[id]/index.tsx
+++ b/pages/terms/[id]/index.tsx
@@ -18,6 +18,7 @@ const Term: React.FC<TermProps> = (props) => {
   if (!props.published) {
     title = `${title} (Draft)`;
   }
+  console.log(props);
 
   return (
     <>
@@ -36,8 +37,8 @@ const Term: React.FC<TermProps> = (props) => {
               <div className="text-h5 md:text-h3 font-bold">Overview</div>
               <div className="">
                 via{" "}
-                <Link href={`/source/${props.sourceId}`} className="underline">
-                  source
+                <Link href={props.source.href} className="underline">
+                  {props.source.title}
                 </Link>
               </div>
             </div>
@@ -98,9 +99,17 @@ const Term: React.FC<TermProps> = (props) => {
 };
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const term = await prisma.term.findUnique({
+  const term = await prisma.term.findFirst({
     where: {
       id: String(params?.id),
+    },
+    include: {
+      source: {
+        select: {
+          title: true,
+          href: true,
+        },
+      },
     },
   });
   return {


### PR DESCRIPTION
Updated the source links which do not redirect to the source website instead of the internal source page. Will add it back later once we flush out source pages more. Then thinned the line separator on the sources page.